### PR TITLE
Add Traefik middleware option

### DIFF
--- a/charts/pgadmin/README.md
+++ b/charts/pgadmin/README.md
@@ -186,6 +186,20 @@ ingress:
           pathType: ImplementationSpecific
 ```
 
+### Deploying behind Cloudflare and Traefik
+
+If pgAdmin is served through Cloudflare with Traefik as the ingress controller,
+use the provided `values.ingress.yaml` file. It sets all `PROXY_X_*_COUNT`
+options to `2` so pgAdmin trusts the forwarded headers from both proxies.
+Set `ingress.createMiddleware=true` to have the chart create a Traefik
+middleware named `<release>-pgadmin-headers` and automatically annotate the
+Ingress. If you deploy the middleware manually, ensure its name and namespace
+match the annotation (e.g. `default-pgadmin-headers@kubernetescrd`).
+If the reference does not match, Traefik cannot bind the router and requests to
+the ingress hostname will result in `404` errors. Also verify the router
+entrypoint (`traefik.ingress.kubernetes.io/router.entrypoints`) matches an
+existing Traefik entrypoint such as `web`.
+
 ### Security
 
 The chart configures security contexts to run pgAdmin as the pgadmin user (UID: 5050) for better security.

--- a/charts/pgadmin/templates/ingress.yaml
+++ b/charts/pgadmin/templates/ingress.yaml
@@ -5,10 +5,13 @@ metadata:
   name: {{ include "pgadmin.fullname" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    {{- if .Values.ingress.createMiddleware }}
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ .Release.Namespace }}-{{ include \"pgadmin.fullname\" . }}-headers@kubernetescrd"
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- with .Values.ingress.className }}
   ingressClassName: {{ . }}

--- a/charts/pgadmin/templates/traefik-middleware.yaml
+++ b/charts/pgadmin/templates/traefik-middleware.yaml
@@ -1,22 +1,22 @@
-# Traefik Middleware for pgAdmin behind Cloudflare
-# Apply this middleware before deploying pgAdmin
-# kubectl apply -f traefik-middleware.yaml
-
+{{- if and .Values.ingress.enabled .Values.ingress.createMiddleware }}
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
-  name: pgadmin-headers
-  namespace: default  # Change to your namespace
+  name: {{ include "pgadmin.fullname" . }}-headers
+  labels:
+    {{- include "pgadmin.labels" . | nindent 4 }}
 spec:
   headers:
     customRequestHeaders:
-      # Tell pgAdmin it's behind HTTPS (Cloudflare handles HTTPS)
       X-Forwarded-Proto: "https"
       X-Forwarded-Port: "443"
       X-Scheme: "https"
-      X-Forwarded-Host: "pgadmin.saas.chatwoot.app.br"
+      {{- with index .Values.ingress.hosts 0 }}
+      X-Forwarded-Host: {{ .host | quote }}
+      {{- end }}
     customResponseHeaders:
       X-Frame-Options: "SAMEORIGIN"
       X-Content-Type-Options: "nosniff"
       X-XSS-Protection: "1; mode=block"
       Referrer-Policy: "strict-origin-when-cross-origin"
+{{- end }}

--- a/charts/pgadmin/values.ingress.yaml
+++ b/charts/pgadmin/values.ingress.yaml
@@ -6,10 +6,10 @@
 ingress:
   enabled: true
   className: "traefik"
+  createMiddleware: true
   annotations:
-    # Headers middleware for pgAdmin behind Cloudflare + Traefik
-    traefik.ingress.kubernetes.io/router.middlewares: "default-pgadmin-headers@kubernetescrd"
-    
+    # The chart will set the router middleware automatically
+    # when createMiddleware is true
     # Use web entrypoint (port 80) since Cloudflare handles HTTPS
     traefik.ingress.kubernetes.io/router.entrypoints: "web"
     
@@ -44,14 +44,12 @@ pgadmin:
     SESSION_EXPIRATION_TIME: 8  # Hours
     
     # Configure proxy settings for Cloudflare + Traefik
-    # Number of values to trust for X-Forwarded-For (Cloudflare sets this)
-    PROXY_X_FOR_COUNT: 1
-    # Number of values to trust for X-Forwarded-Proto (Cloudflare + Traefik set this)
-    PROXY_X_PROTO_COUNT: 1
-    # Number of values to trust for X-Forwarded-Host (Cloudflare + Traefik set this)
-    PROXY_X_HOST_COUNT: 1
-    # Number of values to trust for X-Forwarded-Port (Cloudflare sets this)
-    PROXY_X_PORT_COUNT: 1
+    # Trust two values because requests pass through
+    # Cloudflare and Traefik
+    PROXY_X_FOR_COUNT: 2
+    PROXY_X_PROTO_COUNT: 2
+    PROXY_X_HOST_COUNT: 2
+    PROXY_X_PORT_COUNT: 2
     
     # Secure cookie settings for HTTPS (handled by Cloudflare)
     SESSION_COOKIE_SECURE: True

--- a/charts/pgadmin/values.yaml
+++ b/charts/pgadmin/values.yaml
@@ -121,6 +121,7 @@ service:
 ingress:
   enabled: false
   className: ""
+  createMiddleware: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
## Summary
- add `ingress.createMiddleware` option
- template middleware and annotate Ingress automatically
- document new value and usage in README

## Testing
- `helm lint charts/pgadmin` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68421513070c83259d7eb92d0fc3d778